### PR TITLE
ctlmgr: Environment variables in device db

### DIFF
--- a/artiq_comtools/ctlmgr.py
+++ b/artiq_comtools/ctlmgr.py
@@ -26,6 +26,7 @@ class Controller:
         self.ping_timer = ddb_entry.get("ping_timer", 30)
         self.ping_timeout = ddb_entry.get("ping_timeout", 30)
         self.term_timeout = ddb_entry.get("term_timeout", 30)
+        self.environment = ddb_entry.get("environment", {})
 
         self.retry_timer_cur = self.retry_timer
         self.retry_now = Condition()
@@ -80,9 +81,12 @@ class Controller:
             while True:
                 logger.info("Starting controller %s with command: %s",
                             self.name, self.command)
+                if self.environment:
+                    logger.info("(environment overrides: %s)", self.environment)
                 try:
                     env = os.environ.copy()
                     env["PYTHONUNBUFFERED"] = "1"
+                    env.update(self.environment)
                     self.process = await asyncio.create_subprocess_exec(
                         *shlex.split(self.command),
                         stdout=subprocess.PIPE, stderr=subprocess.PIPE,

--- a/artiq_comtools/test/dummy_controller.py
+++ b/artiq_comtools/test/dummy_controller.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import os
 
 from sipyco.pc_rpc import simple_server_loop
 from sipyco import common_args
@@ -13,6 +14,9 @@ class Dummy:
 
     def ping(self):
         return True
+
+    def get_os_environ(self):
+        return dict(os.environ)
 
 
 def get_argparser():


### PR DESCRIPTION
This allows additional environment variables, or overrides for
ones existing in the inherited environment, to be specified
in the device db in the form of an `environment` dictionary.