### PR TITLE
ctlmgr: Allow explicitly specifying host filter

### DIFF
--- a/artiq_comtools/artiq_ctlmgr.py
+++ b/artiq_comtools/artiq_ctlmgr.py
@@ -32,6 +32,9 @@ def get_argparser():
     parser.add_argument(
         "--retry-master", default=5.0, type=float,
         help="retry timer for reconnecting to master")
+    parser.add_argument(
+        "--host-filter", default=None, help="IP address of controllers to launch "
+        "(local address of master connection by default)")
     common_args.simple_network_args(parser, [("control", "control", 3249)])
     return parser
 
@@ -65,7 +68,7 @@ def main():
     atexit_register_coroutine(logfwd.stop)
 
     ctlmgr = ControllerManager(args.server, args.port_notify,
-                               args.retry_master)
+                               args.retry_master, args.host_filter)
     ctlmgr.start()
     atexit_register_coroutine(ctlmgr.stop)
 

--- a/artiq_comtools/ctlmgr.py
+++ b/artiq_comtools/ctlmgr.py
@@ -222,11 +222,12 @@ class ControllerDB:
 
 
 class ControllerManager(TaskObject):
-    def __init__(self, server, port, retry_master):
+    def __init__(self, server, port, retry_master, host_filter):
         self.server = server
         self.port = port
         self.retry_master = retry_master
         self.controller_db = ControllerDB()
+        self.host_filter = host_filter
 
     async def _do(self):
         try:
@@ -235,9 +236,10 @@ class ControllerManager(TaskObject):
             while True:
                 try:
                     def set_host_filter():
-                        s = subscriber.writer.get_extra_info("socket")
-                        localhost = s.getsockname()[0]
-                        self.controller_db.set_host_filter(localhost)
+                        if self.host_filter is None:
+                            s = subscriber.writer.get_extra_info("socket")
+                            self.host_filter = s.getsockname()[0]
+                        self.controller_db.set_host_filter(self.host_filter)
                     await subscriber.connect(self.server, self.port,
                                              set_host_filter)
                     try:


### PR DESCRIPTION
This is useful for hosts with multiple IP addresses, where all
of them are on the master's subnet as well. In a typical such
setup, it used to be up to chance (or rather the order of
OS-level routes) which of them would be used for the local
socket endpoint, and consequently the host filter.

Another fix would be to change this to filter against all local
IP addresses instead of just one.