### PR TITLE
Prevent traceback at exit

### DIFF
--- a/artiq_comtools/artiq_ctlmgr.py
+++ b/artiq_comtools/artiq_ctlmgr.py
@@ -81,7 +81,10 @@ def main():
                                              args.port_control))
     atexit_register_coroutine(rpc_server.stop)
 
-    loop.run_until_complete(rpc_server.wait_terminate())
+    try:
+        loop.run_until_complete(rpc_server.wait_terminate())
+    except KeyboardInterrupt:
+        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Just catching the `KeyboardInterrupt` to prevent a traceback print at exit.

Signed-off-by: Leon Riesebos <leon.riesebos@duke.edu>