### PR TITLE
Revert "catch keyboard interrupt exception in artiq_ctlmgr to reduce output at exit (#8)"

### DIFF
--- a/artiq_comtools/artiq_ctlmgr.py
+++ b/artiq_comtools/artiq_ctlmgr.py
@@ -81,10 +81,7 @@ def main():
                                              args.port_control))
     atexit_register_coroutine(rpc_server.stop)
 
-    try:
-        loop.run_until_complete(rpc_server.wait_terminate())
-    except KeyboardInterrupt:
-        pass
+    loop.run_until_complete(rpc_server.wait_terminate())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

This reverts commit 487fd7600bc499586776cdd7fe1b6a117816ddac.