### PR TITLE
ctlmgr: format all other args supplied in the controller field

### DIFF
--- a/artiq_comtools/ctlmgr.py
+++ b/artiq_comtools/ctlmgr.py
@@ -185,6 +185,10 @@ class Controllers:
             if (isinstance(v, dict) and v["type"] == "controller" and
                     self.host_filter in get_ip_addresses(v["host"]) and
                     "command" in v):
+                for k_, v_ in v.items():
+                    while isinstance(v_, str) and v_.startswith("@") and v_[1:] in v:
+                        v_ = v[v_[1:]]
+                    v[k_] = v_
                 args = {k: v[k] for k in v if k not in ["type", "command", "host"]}
                 v["command"] = v["command"].format(name=k,
                                                    bind=self.host_filter,

--- a/artiq_comtools/ctlmgr.py
+++ b/artiq_comtools/ctlmgr.py
@@ -10,7 +10,6 @@ from sipyco.pc_rpc import AsyncioClient
 from sipyco.logging_tools import LogParser
 from sipyco.asyncio_tools import TaskObject, Condition
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -186,9 +185,10 @@ class Controllers:
             if (isinstance(v, dict) and v["type"] == "controller" and
                     self.host_filter in get_ip_addresses(v["host"]) and
                     "command" in v):
+                args = {k: v[k] for k in v if k not in ["type", "command", "host"]}
                 v["command"] = v["command"].format(name=k,
                                                    bind=self.host_filter,
-                                                   port=v["port"])
+                                                   **args)
                 self.queue.put_nowait(("set", (k, v)))
                 self.active_or_queued.add(k)
         except:


### PR DESCRIPTION
This one fixes a simple problem where the arguments from moninj proxy aren't formatted correctly. Before that only `port` is rendered in, now all the extra arguments (arguments except `"type", "command", "host"`) will now be formatted in as part of the kwargs.