### PR TITLE
Escape special character

### DIFF
--- a/artiq_comtools/artiq_influxdb.py
+++ b/artiq_comtools/artiq_influxdb.py
@@ -73,7 +73,7 @@ def format_influxdb(v):
     if np.issubdtype(type(v), np.floating):
         return "float={}".format(v)
     if np.issubdtype(type(v), np.str_):
-        return "str=\"{}\"".format(v.replace('"', '\\"').replace('\\\\', '\\'))
+        return "str=\"{}\"".format(v.replace('\\', '\\\\').replace('"', '\\"'))
     return "pyon=\"{}\"".format(pyon.encode(v).replace('"', '\\"'))
 
 

--- a/artiq_comtools/artiq_influxdb.py
+++ b/artiq_comtools/artiq_influxdb.py
@@ -73,7 +73,7 @@ def format_influxdb(v):
     if np.issubdtype(type(v), np.floating):
         return "float={}".format(v)
     if np.issubdtype(type(v), np.str_):
-        return "str=\"{}\"".format(v.replace('"', '\\"'))
+        return "str=\"{}\"".format(v.replace('"', '\\"').replace('\\\\', '\\'))
     return "pyon=\"{}\"".format(pyon.encode(v).replace('"', '\\"'))
 
 
@@ -219,6 +219,7 @@ class Filter:
 
 
 def main():
+    print("HHHHHHHHHHHHHHHH")
     args = get_argparser().parse_args()
     common_args.init_logger_from_args(args)
 

--- a/artiq_comtools/artiq_influxdb.py
+++ b/artiq_comtools/artiq_influxdb.py
@@ -219,7 +219,6 @@ class Filter:
 
 
 def main():
-    print("HHHHHHHHHHHHHHHH")
     args = get_argparser().parse_args()
     common_args.init_logger_from_args(args)
 

--- a/artiq_comtools/artiq_influxdb_schedule.py
+++ b/artiq_comtools/artiq_influxdb_schedule.py
@@ -71,9 +71,7 @@ def format_influxdb(v, tag=True):
             v = v.replace(i, "\\" + i)
         return v
     else:
-        v = "\"{}\"".format(v.replace('"', '\\"'))
-        v = "{}".format(v.replace('\\\\', '\\'))
-        return v
+        return "\"{}\"".format(v.replace('"', '\\"').replace('\\\\', '\\'))
 
 
 class DBWriter(TaskObject):

--- a/artiq_comtools/artiq_influxdb_schedule.py
+++ b/artiq_comtools/artiq_influxdb_schedule.py
@@ -5,7 +5,6 @@ import logging
 import asyncio
 import atexit
 import time
-import json
 
 import aiohttp
 import numpy as np
@@ -72,7 +71,9 @@ def format_influxdb(v, tag=True):
             v = v.replace(i, "\\" + i)
         return v
     else:
-        return json.dumps(v)
+        v = "\"{}\"".format(v.replace('"', '\\"'))
+        v = "{}".format(v.replace('\\\\', '\\'))
+        return v
 
 
 class DBWriter(TaskObject):

--- a/artiq_comtools/artiq_influxdb_schedule.py
+++ b/artiq_comtools/artiq_influxdb_schedule.py
@@ -5,6 +5,7 @@ import logging
 import asyncio
 import atexit
 import time
+import json
 
 import aiohttp
 import numpy as np
@@ -71,7 +72,8 @@ def format_influxdb(v, tag=True):
             v = v.replace(i, "\\" + i)
         return v
     else:
-        return "\"{}\"".format(v.replace('"', '\\"'))
+        print("Dict: {}".format(json.dumps(v)))
+        return json.dumps(v)
 
 
 class DBWriter(TaskObject):

--- a/artiq_comtools/artiq_influxdb_schedule.py
+++ b/artiq_comtools/artiq_influxdb_schedule.py
@@ -71,7 +71,7 @@ def format_influxdb(v, tag=True):
             v = v.replace(i, "\\" + i)
         return v
     else:
-        return "\"{}\"".format(v.replace('"', '\\"').replace('\\\\', '\\'))
+        return "\"{}\"".format(v.replace('\\', '\\\\').replace('"', '\\"'))
 
 
 class DBWriter(TaskObject):

--- a/artiq_comtools/artiq_influxdb_schedule.py
+++ b/artiq_comtools/artiq_influxdb_schedule.py
@@ -72,7 +72,6 @@ def format_influxdb(v, tag=True):
             v = v.replace(i, "\\" + i)
         return v
     else:
-        print("Dict: {}".format(json.dumps(v)))
         return json.dumps(v)
 
 


### PR DESCRIPTION
 influxdb_schedule: Bug with storing string parameters #1454 
The string parameters will convert into JSON formatted string and it will escape the double quotes automatically.
So it won't break when there are values contain an odd number of double quotes, or a combination of double quotes and spaces