### PR TITLE
Flake updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,27 @@
 {
   "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1653920503,
-        "narHash": "sha256-BBeCZwZImtjP3oYy4WogkQYy5OxNyfNciVSc1AfZgLQ=",
+        "lastModified": 1664231666,
+        "narHash": "sha256-5M/40aTCNC34lSPqZIS7zlldRa7n/yNKI1SrpSGAB34=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a634c8f6c1fbf9b9730e01764999666f3436f10a",
+        "rev": "82379884b2e9cf1ba65f5b14bbcb9d1438abb745",
         "type": "github"
       },
       "original": {
@@ -18,6 +33,7 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "sipyco": "sipyco"
       }
@@ -29,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1654001788,
-        "narHash": "sha256-vUSep33N66pcvy7ojnBLSmyyVfN20+WZvP/c4b0T2CI=",
+        "lastModified": 1664319253,
+        "narHash": "sha256-hycJAgy+NFF9f5I6++7yo8KdhMSyKCPKJazRPxeedI4=",
         "owner": "m-labs",
         "repo": "sipyco",
-        "rev": "951de4cf198419712ea3f52991d8f9293f3d9d15",
+        "rev": "d58ded7280e0f020be2446d4fee70f4393e6045f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,28 +4,31 @@
   inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-22.05;
   inputs.sipyco.url = github:m-labs/sipyco;
   inputs.sipyco.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.flake-utils.url = github:numtide/flake-utils;
 
-  outputs = { self, nixpkgs, sipyco }:
-    let
-      pkgs = import nixpkgs { system = "x86_64-linux"; };
-      deps = [ pkgs.python3Packages.numpy pkgs.python3Packages.aiohttp sipyco.packages.x86_64-linux.sipyco ];
-    in rec {
-      packages.x86_64-linux = {
-        artiq-comtools = pkgs.python3Packages.buildPythonPackage {
-          pname = "artiq-comtools";
-          version = "1.1";
-          src = self;
-          propagatedBuildInputs = deps;
+  outputs = { self, nixpkgs, sipyco, flake-utils }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        deps = [ pkgs.python3Packages.numpy pkgs.python3Packages.aiohttp sipyco.packages.${system}.sipyco ];
+      in rec {
+        packages = {
+          artiq-comtools = pkgs.python3Packages.buildPythonPackage {
+            pname = "artiq-comtools";
+            version = "1.1";
+            src = self;
+            propagatedBuildInputs = deps;
+          };
         };
-      };
 
-      defaultPackage.x86_64-linux = packages.x86_64-linux.artiq-comtools;
+        defaultPackage = packages.artiq-comtools;
 
-      devShell.x86_64-linux = pkgs.mkShell {
-        name = "artiq-comtools-dev-shell";
-        buildInputs = [
-          (pkgs.python3.withPackages(ps: deps))
-        ];
-      };
-    };
-}
+        devShell = pkgs.mkShell {
+          name = "artiq-comtools-dev-shell";
+          buildInputs = [
+            (pkgs.python3.withPackages(ps: deps))
+          ];
+        };
+      }
+    );
+  }

--- a/flake.nix
+++ b/flake.nix
@@ -11,19 +11,18 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
         deps = [ pkgs.python3Packages.numpy pkgs.python3Packages.aiohttp sipyco.packages.${system}.sipyco ];
-      in rec {
-        packages = {
+      in {
+        packages = rec {
           artiq-comtools = pkgs.python3Packages.buildPythonPackage {
             pname = "artiq-comtools";
             version = "1.1";
             src = self;
             propagatedBuildInputs = deps;
           };
+          default = artiq-comtools;
         };
 
-        defaultPackage = packages.artiq-comtools;
-
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           name = "artiq-comtools-dev-shell";
           buildInputs = [
             (pkgs.python3.withPackages(ps: deps))


### PR DESCRIPTION
@sbourdeauducq essentially the same as for sipyco, but I used flake-utils here since it's cleaner. My reasoning for not doing the same with sipyco was that it seemed unnecessary to have "multi-architecture" documentation builds, but that's not an issue here. If you don't want the extra dependency I can rewrite it without flake-utils.

Also tested the build on an RPi 4B with nix 2.7.0.