### PR TITLE
Fix asyncio compatibility issues with Python 3.11

### DIFF
--- a/artiq_comtools/artiq_ctlmgr.py
+++ b/artiq_comtools/artiq_ctlmgr.py
@@ -81,7 +81,8 @@ def main():
     atexit_register_coroutine(rpc_server.stop)
 
     _, pending = loop.run_until_complete(asyncio.wait(
-        [signal_handler.wait_terminate(), rpc_server.wait_terminate()],
+        [asyncio.create_task(signal_handler.wait_terminate()),
+         asyncio.create_task(rpc_server.wait_terminate())],
         return_when=asyncio.FIRST_COMPLETED))
     for task in pending:
         task.cancel()

--- a/artiq_comtools/artiq_ctlmgr.py
+++ b/artiq_comtools/artiq_ctlmgr.py
@@ -81,8 +81,8 @@ def main():
     atexit_register_coroutine(rpc_server.stop)
 
     _, pending = loop.run_until_complete(asyncio.wait(
-        [asyncio.create_task(signal_handler.wait_terminate()),
-         asyncio.create_task(rpc_server.wait_terminate())],
+        [loop.create_task(signal_handler.wait_terminate()),
+         loop.create_task(rpc_server.wait_terminate())],
         return_when=asyncio.FIRST_COMPLETED))
     for task in pending:
         task.cancel()

--- a/artiq_comtools/artiq_influxdb.py
+++ b/artiq_comtools/artiq_influxdb.py
@@ -247,7 +247,8 @@ def main():
     atexit_register_coroutine(reader.stop)
 
     _, pending = loop.run_until_complete(asyncio.wait(
-        [signal_handler.wait_terminate(), rpc_server.wait_terminate()],
+        [asyncio.create_task(signal_handler.wait_terminate()),
+         asyncio.create_task(rpc_server.wait_terminate())],
         return_when=asyncio.FIRST_COMPLETED))
     for task in pending:
         task.cancel()

--- a/artiq_comtools/artiq_influxdb.py
+++ b/artiq_comtools/artiq_influxdb.py
@@ -247,8 +247,8 @@ def main():
     atexit_register_coroutine(reader.stop)
 
     _, pending = loop.run_until_complete(asyncio.wait(
-        [asyncio.create_task(signal_handler.wait_terminate()),
-         asyncio.create_task(rpc_server.wait_terminate())],
+        [loop.create_task(signal_handler.wait_terminate()),
+         loop.create_task(rpc_server.wait_terminate())],
         return_when=asyncio.FIRST_COMPLETED))
     for task in pending:
         task.cancel()

--- a/artiq_comtools/artiq_influxdb_schedule.py
+++ b/artiq_comtools/artiq_influxdb_schedule.py
@@ -238,7 +238,8 @@ def main():
     atexit_register_coroutine(reader.stop)
 
     _, pending = loop.run_until_complete(asyncio.wait(
-        [signal_handler.wait_terminate(), rpc_server.wait_terminate()],
+        [asyncio.create_task(signal_handler.wait_terminate()),
+         asyncio.create_task(rpc_server.wait_terminate())],
         return_when=asyncio.FIRST_COMPLETED))
     for task in pending:
         task.cancel()

--- a/artiq_comtools/artiq_influxdb_schedule.py
+++ b/artiq_comtools/artiq_influxdb_schedule.py
@@ -238,8 +238,8 @@ def main():
     atexit_register_coroutine(reader.stop)
 
     _, pending = loop.run_until_complete(asyncio.wait(
-        [asyncio.create_task(signal_handler.wait_terminate()),
-         asyncio.create_task(rpc_server.wait_terminate())],
+        [loop.create_task(signal_handler.wait_terminate()),
+         loop.create_task(rpc_server.wait_terminate())],
         return_when=asyncio.FIRST_COMPLETED))
     for task in pending:
         task.cancel()


### PR DESCRIPTION
### Description

Issue was raised here:
https://forum.m-labs.hk/d/698-missing-compatibility-fix-for-python-311-in-artiq-comtools

Applied the same fix from sipyco:
- [Python 3.11 compatibility fix](https://github.com/m-labs/sipyco/commit/f39f22b0aabed0a8edb915f194955c8b21137375)
- [fix asyncio event loop management](https://github.com/m-labs/sipyco/commit/91a7906bdbb102c0162ac054f5342c657f62e354)

Errors were gone for:
`artiq_influxdb` `artiq_influxdb_schedule` and `artiq_ctlmgr` and now can try to connect to server.
