### PR TITLE
ctlmgr: Add status message

### DIFF
--- a/artiq_comtools/artiq_ctlmgr.py
+++ b/artiq_comtools/artiq_ctlmgr.py
@@ -80,6 +80,7 @@ def main():
                                              args.port_control))
     atexit_register_coroutine(rpc_server.stop)
 
+    print("ARTIQ controller manager is now running.")
     _, pending = loop.run_until_complete(asyncio.wait(
         [loop.create_task(signal_handler.wait_terminate()),
          loop.create_task(rpc_server.wait_terminate())],


### PR DESCRIPTION
Adds startup message to match master's "ARTIQ master is now ready", in place of a totally silent startup.  