### PR TITLE
ctlmgr: fix controllers remaining after terminal close

### DIFF
--- a/artiq_comtools/ctlmgr.py
+++ b/artiq_comtools/ctlmgr.py
@@ -89,8 +89,7 @@ class Controller:
                     env.update(self.environment)
                     self.process = await asyncio.create_subprocess_exec(
                         *shlex.split(self.command),
-                        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                        env=env, start_new_session=True)
+                        stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
                     asyncio.ensure_future(
                         LogParser(self._get_log_source).stream_task(
                             self.process.stdout))


### PR DESCRIPTION
### Description

Set `start_new_session=False` (default) to keep controllers in parent's process group. Terminal close now terminates controllers same as Ctrl+C.

**strace log:**
- `186071` - artiq_ctlmgr
- `186072` - controller
```
sudo strace -p 186071 -e signal
strace: Process 186071 attached
--- SIGHUP {si_signo=SIGHUP, si_code=SI_KERNEL} ---
--- SIGCONT {si_signo=SIGCONT, si_code=SI_KERNEL} ---
rt_sigreturn({mask=[]})                 = -1 EINTR (Interrupted system call)
kill(186072, SIGTERM)                   = 0
--- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_KILLED, si_pid=186072, si_uid=1000, si_status=SIGTERM, si_utime=11 /* 0.11 s */, si_stime=1 /* 0.01 s */} ---
rt_sigaction(SIGINT, {sa_handler=0x7ffff7951530, sa_mask=[], sa_flags=SA_RESTORER|SA_ONSTACK, sa_restorer=0x7ffff7560620}, {sa_handler=0x7ffff7951530, sa_mask=[], sa_flags=SA_RESTORER|SA_ONSTACK, sa_restorer=0x7ffff7560620}, 8) = 0
rt_sigaction(SIGTERM, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=SA_RESTORER|SA_ONSTACK, sa_restorer=0x7ffff7560620}, {sa_handler=0x7ffff7951530, sa_mask=[], sa_flags=SA_RESTORER|SA_ONSTACK, sa_restorer=0x7ffff7560620}, 8) = 0
rt_sigaction(SIGHUP, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=SA_RESTORER|SA_ONSTACK, sa_restorer=0x7ffff7560620}, {sa_handler=0x7ffff7951530, sa_mask=[], sa_flags=SA_RESTORER|SA_ONSTACK, sa_restorer=0x7ffff7560620}, 8) = 0
rt_sigaction(SIGINT, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=SA_RESTORER|SA_ONSTACK, sa_restorer=0x7ffff7560620}, {sa_handler=0x7ffff7951530, sa_mask=[], sa_flags=SA_RESTORER|SA_ONSTACK, sa_restorer=0x7ffff7560620}, 8) = 0
+++ exited with 120 +++
```

TODO: add similar handling for Windows
Revert: https://github.com/m-labs/sipyco/pull/49


Closes https://github.com/m-labs/artiq/issues/2614