### PR TITLE
flake: fix python PATH propagation to subprocesses

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,11 @@
             pyproject = true;
             build-system = [ pkgs.python3Packages.setuptools ];
             propagatedBuildInputs = deps;
+            # Modifies PATH to pass the wrapped python environment (i.e. python3.withPackages(...) to subprocesses.
+            # Allows subprocesses using python to find all packages you have installed
+            makeWrapperArgs = [
+              ''--run 'if [ ! -z "$NIX_PYTHONPREFIX" ]; then export PATH=$NIX_PYTHONPREFIX/bin:$PATH;fi' ''
+            ];
           };
           default = artiq-comtools;
         };


### PR DESCRIPTION
Fix recurring issue from: https://forum.m-labs.hk/d/994-artiq-interacts-with-external-devices-connected-to-the-host-serial-port/9 and https://github.com/m-labs/artiq-comtools/issues/7#issuecomment-2640368573, when using the `ctlmgr` from the minimal Nix ARTIQ flake environment in the manual.

Re-apply the patch from: https://github.com/m-labs/artiq-comtools/issues/7#issuecomment-749801390 which was dropped during the migration to flakes.