### PR TITLE
ctlmgr exit when ssl fails

### DIFF
--- a/artiq_comtools/artiq_ctlmgr.py
+++ b/artiq_comtools/artiq_ctlmgr.py
@@ -92,7 +92,8 @@ def main():
     print("ARTIQ controller manager is now running.")
     _, pending = loop.run_until_complete(asyncio.wait(
         [loop.create_task(signal_handler.wait_terminate()),
-         loop.create_task(rpc_server.wait_terminate())],
+        loop.create_task(rpc_server.wait_terminate()),
+        ctlmgr.task],
         return_when=asyncio.FIRST_COMPLETED))
     for task in pending:
         task.cancel()

--- a/artiq_comtools/ctlmgr.py
+++ b/artiq_comtools/ctlmgr.py
@@ -4,6 +4,7 @@ import subprocess
 import shlex
 import socket
 import os
+import ssl
 
 from sipyco.sync_struct import Subscriber
 from sipyco.pc_rpc import AsyncioClient
@@ -266,6 +267,10 @@ class ControllerManager(TaskObject):
                         await asyncio.wait_for(subscriber.receive_task, None)
                     finally:
                         await subscriber.close()
+                except (ssl.SSLError) as e:
+                    logger.error("SSL failed (%s: %s)",
+                                   e.__class__.__name__, str(e))
+                    raise
                 except (ConnectionAbortedError, ConnectionError,
                         ConnectionRefusedError, ConnectionResetError) as e:
                     logger.warning("Connection to master failed (%s: %s)",


### PR DESCRIPTION
Make ctlmgr exit when SSL fails due to wrong key config or wrong peer config, instead of keeps running or retrying (because they cannot be recovered through retrying).
By adding SSL error exception in `ControllerManager __do` loop, and add return condition in `main().`

For SSL failure due to a wrong client config, need some method to distinguish it with an ordinary network failure.